### PR TITLE
Rescue urllib3.exceptions.LocationParseError...

### DIFF
--- a/nw_log4jcheck.py
+++ b/nw_log4jcheck.py
@@ -9,7 +9,7 @@ import argparse
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(level=logging.INFO)
 
-# Change this to your DNS zone 
+# Change this to your DNS zone
 HOSTNAME = "yourdns.zone.here"
 
 header_injects = [
@@ -48,6 +48,8 @@ def send_request(url, headers={}, timeout=5):
         logging.error(f"HTTP connection to target URL error: {e}")
     except requests.exceptions.Timeout:
         logging.error("HTTP request timeout")
+    except (requests.exceptions.InvalidURL, urllib3.exceptions.LocationParseError) as e:
+        logging.error(f"Failed to parse URL: {e}")
 
 def check_urls(urls, wait, timeout):
     url_identifiers=dict()


### PR DESCRIPTION
... to at least continue processing lists

I was running a scan in a tmux just do find out the tool doesn't really like ipv6 ip addresses or some other entries in my list. It would be easier to just continue scanning. The operator in any case still has to check the output to see if something failed.